### PR TITLE
Hotfix to get work around _shapeOrig issue

### DIFF
--- a/sr_impex/__init__.py
+++ b/sr_impex/__init__.py
@@ -24,7 +24,7 @@ bl_info = {
     "author": "Maxxxel",
     "description": "Addon for importing and exporting Spellforce 2 drs/bmg files.",
     "blender": (4, 4, 0),
-    "version": (3, 3, 0),
+    "version": (3, 3, 1),
     "location": "File > Import",
     "warning": "",
     "category": "Import-Export",

--- a/sr_impex/drs_definitions.py
+++ b/sr_impex/drs_definitions.py
@@ -3111,7 +3111,11 @@ class DRS:
                 setattr(self, node_information_map[node_info.magic], node_info)
                 self.node_informations.append(node_info)
             else:
-                raise TypeError(f"Unknown Node: {node_info.magic}")
+                #specifically SF2 uses a lot of _shapeOrig nodes with different magic left right and center. 
+                #to avoid crashes every time let's have work around to make them at least importable
+                setattr(self, "unknown_node", node_info)
+                self.node_informations.append(node_info)
+                #raise TypeError(f"Unknown Node: {node_info.magic}")
         
         # Read Node Hierarchy
         reader.seek(self.node_hierarchy_offset)


### PR DESCRIPTION
Removed exception for unknown magic node too avoid bloating the node_information_map
I've strong suspicion that for each _addon.drs building, aka animated attachement we encounted _shapeOrig node with different magic
I suppose best approach would be either to ignore them for time being
I suppose, based on the naming, that they can hold reference to parent model in some way, shape or form 